### PR TITLE
ci: fixes release please failed to generate a release pr (resolves #61)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,12 +2,25 @@ on:
   push:
     branches:
       - main
+
 name: release-please
+
 jobs:
   release-please:
+    if: github.repository == 'fluid-project/uio-plus'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GHA_APP_ID }}
+          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
             "extra-files": [
                 {
                     "type": "json",
-                    "path": "src/manifest.json"
+                    "path": "src/manifest.json",
+                    "jsonpath": "$.version"
                 }
             ]
         }


### PR DESCRIPTION
Resolves #61 

- Sets the jsonpath for the manifest.json file
- Uses the GitHub app for permissions to perform the release